### PR TITLE
Bug fix 9

### DIFF
--- a/actor_fault_tolerance/include/actor_guard.h
+++ b/actor_fault_tolerance/include/actor_guard.h
@@ -16,10 +16,12 @@ class ActorGuard {
  public:
   ActorGuard(caf::actor& keepActor,
              std::function<caf::actor(std::atomic<bool>&)> restart,
-             caf::actor_system& system)
+             caf::actor_system& system,
+             std::chrono::seconds timeout_in_seconds = std::chrono::seconds(30))
       : keep_actor_(keepActor),
         restart_fun_(std::move(restart)),
-        sender_actor_(system) {}
+        sender_actor_(system),
+        timeout_in_seconds_(timeout_in_seconds) {}
 
   template <class... send_type, class return_function_type>
   bool SendAndReceive(return_function_type return_function,
@@ -28,7 +30,7 @@ class ActorGuard {
     if (active_) {
       caf::message send_message = caf::make_message(messages...);
 
-      sender_actor_->request(keep_actor_, std::chrono::seconds(1), messages...)
+      sender_actor_->request(keep_actor_, timeout_in_seconds_, messages...)
           .receive(return_function, [&](caf::error err) {
             HandleSendFailed(send_message, return_function, error_deal_function,
                              err);
@@ -67,6 +69,7 @@ class ActorGuard {
   caf::scoped_actor sender_actor_;
   std::function<caf::actor(std::atomic<bool>&)> restart_fun_;
   std::atomic<bool> active_ = true;
+  std::chrono::seconds timeout_in_seconds_;
 };
 
 #endif  // ACTOR_FAULT_TOLERANCE_INCLUDE_ACTOR_GUARD_H_

--- a/actor_fault_tolerance/include/actor_union.h
+++ b/actor_fault_tolerance/include/actor_union.h
@@ -18,7 +18,9 @@ std::string to_string(actor_union_error x);
 
 class ActorUnion {
  public:
-  ActorUnion(caf::actor_system& system, caf::actor_pool::policy policy);
+  ActorUnion(
+      caf::actor_system& system, caf::actor_pool::policy policy,
+      std::chrono::seconds timeout_in_seconds = std::chrono::seconds(30));
   virtual ~ActorUnion();
   void AddActor(const caf::actor& actor);
   void RemoveActor(const caf::actor& actor);
@@ -35,6 +37,7 @@ class ActorUnion {
   caf::scoped_execution_unit* context_;
   caf::scoped_actor sender_actor_;
   uint16_t actor_count_ = 0;
+  std::chrono::seconds timeout_in_seconds_;
 
   template <class... send_type, class return_function_type>
   void SendAndReceiveWithTryTime(
@@ -42,7 +45,7 @@ class ActorUnion {
       std::function<void(caf::error)> handle_error_function,
       uint16_t has_try_time, const send_type&... messages) {
     caf::message send_message = caf::make_message(messages...);
-    sender_actor_->request(pool_actor_, std::chrono::seconds(1), messages...)
+    sender_actor_->request(pool_actor_, timeout_in_seconds_, messages...)
         .receive(return_function, [=](caf::error err) {
           HandleSendFailed(send_message, return_function, handle_error_function,
                            err, has_try_time);

--- a/actor_fault_tolerance/src/actor_fault_torlerance_test.cc
+++ b/actor_fault_tolerance/src/actor_fault_torlerance_test.cc
@@ -151,6 +151,44 @@ TEST_F(ActorUnionTest, all_error_actor) {
   EXPECT_EQ(true, error);
 }
 
+TEST_F(ActorUnionTest, should_not_failed_when_actor_not_exceed_timeout) {
+  auto actor = system_.spawn(calculator_timeout, 2);
+  actorUnion_.AddActor(actor);
+  std::promise<int> promise;
+  bool error = false;
+
+  actorUnion_.SendAndReceive(
+      [&](int return_value) { promise.set_value(return_value); },
+      [&](const caf::error&) {
+        error = true;
+        promise.set_value(0);
+      },
+      add_atom::value, 3, 5);
+
+  promise.get_future().get();
+  EXPECT_EQ(error, false);
+}
+
+TEST_F(ActorUnionTest, should_failed_when_actor_exceed_timeout) {
+  auto actor = system_.spawn(calculator_timeout, 2);
+  actorUnion_.AddActor(actor);
+  std::promise<int> promise;
+  bool error = false;
+
+  ActorUnion actor_union{system_, caf::actor_pool::round_robin(),
+                         std::chrono::seconds(1)};
+  actor_union.SendAndReceive(
+      [&](int return_value) { promise.set_value(return_value); },
+      [&](const caf::error&) {
+        error = true;
+        promise.set_value(0);
+      },
+      add_atom::value, 3, 5);
+
+  promise.get_future().get();
+  EXPECT_EQ(error, true);
+}
+
 class ActorGuardTest : public ::testing::Test {
   void SetUp() override {
     // TODO(Yujia.Li): Bad naming

--- a/actor_fault_tolerance/src/actor_union.cc
+++ b/actor_fault_tolerance/src/actor_union.cc
@@ -5,8 +5,9 @@
 #include "../include/actor_union.h"
 
 ActorUnion::ActorUnion(caf::actor_system& system,
-                       caf::actor_pool::policy policy)
-    : sender_actor_(system) {
+                       caf::actor_pool::policy policy,
+                       std::chrono::seconds timeout_in_seconds)
+    : sender_actor_(system), timeout_in_seconds_(timeout_in_seconds) {
   context_ = new caf::scoped_execution_unit(&system);
   pool_actor_ = caf::actor_pool::make(context_, std::move(policy));
 }

--- a/demos/yanghui_cluster/actor_union_count_cluster.cc
+++ b/demos/yanghui_cluster/actor_union_count_cluster.cc
@@ -46,7 +46,11 @@ int ActorUnionCountCluster::AddNumber(int a, int b, int& result) {
   std::cout << "start add task input:" << a << ", " << b << std::endl;
 
   counter_.SendAndReceive([&](int ret) { promise.set_value(ret); },
-                          [&](const caf::error& err) { error = 1; }, a, b);
+                          [&](const caf::error& err) {
+                            promise.set_value(INT_MAX);
+                            error = 1;
+                          },
+                          a, b);
 
   result = promise.get_future().get();
 
@@ -73,7 +77,11 @@ int ActorUnionCountCluster::Compare(std::vector<int> numbers, int& min) {
         min = ret;
         promise.set_value(ret);
       },
-      [&](const caf::error& err) { error = 1; }, send_data);
+      [&](const caf::error& err) {
+        promise.set_value(INT_MAX);
+        error = 1;
+      },
+      send_data);
 
   min = promise.get_future().get();
   std::cout << "get min:" << min << std::endl;

--- a/demos/yanghui_cluster/actor_union_count_cluster.cc
+++ b/demos/yanghui_cluster/actor_union_count_cluster.cc
@@ -3,6 +3,8 @@
  */
 #include "include/actor_union_count_cluster.h"
 
+#include <limits.h>
+
 #include <caf/openssl/all.hpp>
 
 void ActorUnionCountCluster::AddWorkerNodeWithPort(const std::string& host,

--- a/demos/yanghui_cluster/yanghui_example_v2.cc
+++ b/demos/yanghui_cluster/yanghui_example_v2.cc
@@ -354,8 +354,9 @@ void SmartRootStart(caf::actor_system& system, const config& cfg) {
   auto pool_actor = system.spawn(yanghui, pool_cluster);
   std::cout << "pool_actor for router pool job spawned with id: "
             << pool_actor.id() << std::endl;
-  actor_status_monitor.RegisterActor(pool_actor, "Yanghui",
-                                     "a actor can count yanghui triangle.");
+  actor_status_monitor.RegisterActor(
+      pool_actor, "Yanghui",
+      "a actor can count yanghui triangle using pool cluster.");
 
   auto pool_supervisor = system.spawn<ActorMonitor>(downMsgHandle);
   SetMonitor(pool_supervisor, pool_actor, "worker actor for testing");
@@ -365,8 +366,12 @@ void SmartRootStart(caf::actor_system& system, const config& cfg) {
       [&](std::atomic<bool>& active) {
         active = true;
         auto new_yanghui = system.spawn(yanghui, pool_cluster);
+        CDCF_LOGGER_ERROR(
+            "yanghui actor for pool cluster failed. spawn new one: {}",
+            caf::to_string(new_yanghui.address()));
         actor_status_monitor.RegisterActor(
-            pool_actor, "Yanghui", "a actor can count yanghui triangle.");
+            new_yanghui, "Yanghui",
+            "a actor can count yanghui triangle using pool cluster.");
         // SetMonitor(supervisor, yanghui_actor, "worker actor for testing");
         return new_yanghui;
       },
@@ -400,8 +405,9 @@ void SmartRootStart(caf::actor_system& system, const config& cfg) {
   std::cout << "yanghui_actor for standard job spawned with id: "
             << yanghui_actor.id() << std::endl;
 
-  actor_status_monitor.RegisterActor(yanghui_actor, "Yanghui",
-                                     "a actor can count yanghui triangle.");
+  actor_status_monitor.RegisterActor(
+      yanghui_actor, "Yanghui",
+      "a actor can count yanghui triangle using count cluster.");
 
   std::cout << "yanghui server ready to work, press 'n', 'p', 'b' or 'e' to "
                "go, 'q' to stop"
@@ -415,8 +421,12 @@ void SmartRootStart(caf::actor_system& system, const config& cfg) {
       [&](std::atomic<bool>& active) {
         active = true;
         auto new_yanghui = system.spawn(yanghui, count_cluster);
+        CDCF_LOGGER_ERROR(
+            "yanghui actor for count cluster failed. spawn new one: {}",
+            caf::to_string(new_yanghui.address()));
         actor_status_monitor.RegisterActor(
-            yanghui_actor, "Yanghui", "a actor can count yanghui triangle.");
+            new_yanghui, "Yanghui",
+            "a actor can count yanghui triangle using countcluster.");
         // SetMonitor(supervisor, yanghui_actor, "worker actor for testing");
         return new_yanghui;
       },

--- a/demos/yanghui_cluster/yanghui_server.cc
+++ b/demos/yanghui_cluster/yanghui_server.cc
@@ -4,10 +4,6 @@
 
 #include "./include/yanghui_server.h"
 
-void ErrorHandler(const caf::error& err) {
-  std::cout << "call actor get error:" << caf::to_string(err) << std::endl;
-}
-
 caf::behavior yanghui_standard_job_actor_fun(
     caf::stateful_actor<yanghui_job_state>* self, ActorGuard* actor_guard) {
   return {[=](const YanghuiData& data) {
@@ -19,7 +15,12 @@ caf::behavior yanghui_standard_job_actor_fun(
         [&](int result) {
           self->send(caf::actor_cast<caf::actor>(sender), true, result);
         },
-        ErrorHandler, yanghui_data);
+        [&](const caf::error& err) {
+          std::cout << "call actor get error:" << caf::to_string(err)
+                    << std::endl;
+          self->send(caf::actor_cast<caf::actor>(sender), false, INT_MAX);
+        },
+        yanghui_data);
   }};
 }
 
@@ -84,6 +85,11 @@ caf::behavior yanghui_router_pool_job_actor_fun(
         [&](int result) {
           self->send(caf::actor_cast<caf::actor>(sender), true, result);
         },
-        ErrorHandler, yanghui_data);
+        [&](const caf::error& err) {
+          std::cout << "call actor get error:" << caf::to_string(err)
+                    << std::endl;
+          self->send(caf::actor_cast<caf::actor>(sender), false, INT_MAX);
+        },
+        yanghui_data);
   }};
 }

--- a/demos/yanghui_cluster/yanghui_server.cc
+++ b/demos/yanghui_cluster/yanghui_server.cc
@@ -4,6 +4,8 @@
 
 #include "./include/yanghui_server.h"
 
+#include <limits.h>
+
 caf::behavior yanghui_standard_job_actor_fun(
     caf::stateful_actor<yanghui_job_state>* self, ActorGuard* actor_guard) {
   return {[=](const YanghuiData& data) {


### PR DESCRIPTION
actor_union没有正确处理promise，导致程序卡住（修改方案：在错误处理中加入promise.set）
ActorGuard、ActorUnion 1s超时不合理（临时方案：加入timeout，单位为秒）
计算失败时没有向client返错（修改方案：向client返错）
重启callback应该把新actor注册上去，而不是旧的
重启callback应该多打印一些有用的信息